### PR TITLE
simplifyExpr: rewrite PKE_DEC(sk, PK_ENC(G^sk, m)) -> m

### DIFF
--- a/data/equivalence6.vp
+++ b/data/equivalence6.vp
@@ -1,0 +1,24 @@
+attacker[passive]
+principal A[
+   generates key_a
+   pk_a = G^key_a
+]
+
+A -> B: pk_a
+
+principal B[
+    generates message
+    ciphertext = PKE_ENC(pk_a, message)
+]
+
+B -> A: ciphertext
+
+principal A[
+   decrypted = PKE_DEC(key_a, ciphertext)
+]
+
+queries[
+    equivalence? decrypted, message
+    confidentiality? message
+    confidentiality? key_a
+]

--- a/src/VerifPal/Check.hs
+++ b/src/VerifPal/Check.hs
@@ -960,6 +960,14 @@ equationToList acc c =
 simplifyExpr' :: Bool -> CanonExpr -> CanonExpr
 simplifyExpr' skipPrimitive e = do
   case e of
+    CPrimitive (PKE_DEC skey enc) _
+      | not skipPrimitive -> do
+          let s_skey = simplifyExpr skey
+              s_enc  = simplifyExpr enc
+          case s_enc of
+            CPrimitive (PKE_ENC pk plaintext) _
+              | equivalenceExpr (CG s_skey) pk -> plaintext
+            _ -> e
     CPrimitive (SHAMIR_JOIN
                 ( CItem idxa (CPrimitive (SHAMIR_SPLIT e_a) _))
                 ( CItem idxb (CPrimitive (SHAMIR_SPLIT e_b)_))

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -387,6 +387,11 @@ equivalence5 = $(embedStringFile "data/equivalence5.vp")
 equivalence5_ast :: Model
 equivalence5_ast = assertParseModel equivalence5
 
+equivalence6 :: Text
+equivalence6 = $(embedStringFile "data/equivalence6.vp")
+equivalence6_ast :: Model
+equivalence6_ast = assertParseModel equivalence6
+
 abknows :: Text
 abknows = $(embedStringFile "data/abknows.vp")
 

--- a/test/CheckTest.hs
+++ b/test/CheckTest.hs
@@ -364,6 +364,15 @@ spec_equivalence = do
       shouldNotFail modelState
       -- TODO should NOT have: modelState `shouldHaveEquivalence` ["a", "b"]
       modelState `shouldHaveEquivalence` ["gyx", "gxy"]
+    let msEquivalence6 = process equivalence6_ast
+    it "checks equivalence6 model" $ do
+      shouldNotFail msEquivalence6
+    it "checks equivalence6 query: : m = PKE_DEC(sk, PKE_ENC(pk, m))" $ do
+      msEquivalence6 `shouldHaveEquivalence` ["decrypted", "message"]
+    it "checks equivalence6: confidentiality? message" $ do
+      msEquivalence6 `shouldHaveConfidentiality` "message"
+    it "checks equivalence6: confidentiality? key_a" $ do
+      msEquivalence6 `shouldHaveConfidentiality` "key_a"
 
 spec_confidentiality :: Spec
 spec_confidentiality = do


### PR DESCRIPTION
The `equivalence?` queries probably has a few more missing cases, but I ran into one today, as illustrated by the test case.

Fix was simple. :-)

ping @sshine