### PR TITLE
Add (failing) test cases for authentication? queries

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,7 +11,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Text.Lazy as Text.Lazy
-import Error.Diagnose (addFile, printDiagnostic)
+import Error.Diagnose (addFile, printDiagnostic, Note, defaultStyle)
 import Error.Diagnose.Compat.Megaparsec (errorDiagnosticFromBundle)
 import Options.Applicative
 import Prettyprinter.Render.Terminal (putDoc)
@@ -51,11 +51,11 @@ argsHandler Args {..} = do
     Left bundle ->
       let short = Nothing :: Maybe Text
           explanation = "Parse error on input"
-          extra_hints = Nothing :: Maybe [Text] -- in addition to the HasHints lookup?
+          extra_hints = Nothing :: Maybe [Error.Diagnose.Note Text] -- in addition to the HasHints lookup?
           diag = errorDiagnosticFromBundle short explanation extra_hints bundle
           fake_filename = "" -- TODO Parser.hs feeds in "" as the filename to "parse"
           diag' = addFile diag fake_filename (Text.unpack srcText)
-       in printDiagnostic stderr True True 4 diag'
+       in printDiagnostic stderr True True 4 defaultStyle diag'
 
     Right model -> do
       Text.hPutStrLn stderr ("Processing file " <> Text.pack srcFile)

--- a/data/authentication1.vp
+++ b/data/authentication1.vp
@@ -1,0 +1,16 @@
+// example from the verifpal paper, section 2.4
+attacker[passive]
+
+principal Carol[]
+principal Alice[
+  generates m2
+]
+Alice->Carol: m2
+principal Bob[
+  generates e
+]
+Bob->Alice: e
+
+
+queries[authentication? Bob->Alice: e[
+  precondition[Alice->Carol: m2]]]

--- a/data/authentication2.vp
+++ b/data/authentication2.vp
@@ -1,0 +1,14 @@
+// from verifpal paper, section 2.3
+attacker[passive]
+
+principal Alice[]
+
+principal Bob[
+    generates e1
+]
+
+Bob->Alice: e1
+
+queries [
+    authentication? Bob->Alice: e1
+]

--- a/data/authentication3.vp
+++ b/data/authentication3.vp
@@ -1,0 +1,14 @@
+attacker[passive]
+
+principal Alice[]
+
+principal Bob[
+    generates e1
+]
+
+Bob->Alice: e1
+
+// empty queryOptions without any queryOption:
+queries [
+    authentication? Bob->Alice: e1 []
+]

--- a/data/authentication4.vp
+++ b/data/authentication4.vp
@@ -1,0 +1,19 @@
+attacker[passive]
+
+principal Alice[]
+
+principal Bob[
+    generates e1, e2, e3
+]
+
+Bob->Alice: e1
+
+
+// multiple queryOption
+// the e3 queryOption has a guardedConstant
+queries [
+    authentication? Bob->Alice: e1 [
+      precondition[ Bob->Alice: e2 ]
+      precondition[ Bob->Alice: e3 [e3] ]
+    ]
+]

--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,7 @@ dependencies:
   - githash
   - prettyprinter
   - prettyprinter-ansi-terminal
-  - diagnose == 1.8.1
+  - diagnose == 2.4.0
   - pretty-show
 
 default-extensions:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-18.12
 extra-deps:
-  - diagnose-1.8.1@sha256:2e799c0b2bba76a9c134ea537a8b36bc7a10313819d99c27e3f9934c73d3a5d9,5707
+    - diagnose-2.4.0
 flags:
   diagnose:
     megaparsec-compat: true

--- a/test/Cases.hs
+++ b/test/Cases.hs
@@ -387,6 +387,18 @@ equivalence5 = $(embedStringFile "data/equivalence5.vp")
 equivalence5_ast :: Model
 equivalence5_ast = assertParseModel equivalence5
 
+authentication1 :: Text
+authentication1 = $(embedStringFile "data/authentication1.vp")
+
+authentication2 :: Text
+authentication2 = $(embedStringFile "data/authentication2.vp")
+
+authentication3 :: Text
+authentication3 = $(embedStringFile "data/authentication3.vp")
+
+authentication4 :: Text
+authentication4 = $(embedStringFile "data/authentication4.vp")
+
 abknows :: Text
 abknows = $(embedStringFile "data/abknows.vp")
 

--- a/test/CheckTest.hs
+++ b/test/CheckTest.hs
@@ -21,6 +21,7 @@ import qualified Hedgehog.Range
 import Test.Tasty.Hspec
 
 import VerifPal.Types
+import VerifPal.Parser (parseModel)
 import VerifPal.Check (process, ModelState(..), ModelError(..), ProcessingCounter, CanonExpr(..),CanonKnowledge(..), equationToList, equivalenceExpr, simplifyExpr, decanonicalizeExpr, mapPrimitiveP, emptyModelState)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -83,6 +84,12 @@ shouldHave modelState (principalName, constants) =
     Nothing -> fail "Principal not found" -- True `shouldBe` False
     Just principalMap ->
       forM_ constants (\constant -> Map.member constant principalMap `shouldBe` True)
+
+shouldParse :: Text -> Expectation
+shouldParse modelSrc =
+  case parseModel modelSrc of
+    Left bundle -> fail (show bundle) -- better than nothing, not very pretty. TODO.
+    Right _ -> pure ()
 
 shouldHaveEquivalence :: ModelState -> [Text] -> Expectation
 shouldHaveEquivalence modelState wantedConstants =
@@ -364,6 +371,18 @@ spec_equivalence = do
       shouldNotFail modelState
       -- TODO should NOT have: modelState `shouldHaveEquivalence` ["a", "b"]
       modelState `shouldHaveEquivalence` ["gyx", "gxy"]
+
+spec_authentication :: Spec
+spec_authentication = do
+  describe "parse" $ do
+    it "parses authentication1" $ do
+      shouldParse authentication1
+    it "parses authentication2" $ do
+      shouldParse authentication2
+    it "parses authentication3" $ do
+      shouldParse authentication3
+    it "parses authentication4" $ do
+      shouldParse authentication4
 
 spec_confidentiality :: Spec
 spec_confidentiality = do

--- a/verifairy.cabal
+++ b/verifairy.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,7 +28,7 @@ library
   build-depends:
       base
     , containers
-    , diagnose ==1.8.1
+    , diagnose ==2.4.0
     , fgl
     , githash
     , megaparsec
@@ -52,7 +52,7 @@ executable verifairy
   build-depends:
       base
     , containers
-    , diagnose ==1.8.1
+    , diagnose ==2.4.0
     , fgl
     , filepath
     , githash
@@ -85,7 +85,7 @@ test-suite test
   build-depends:
       base
     , containers
-    , diagnose ==1.8.1
+    , diagnose ==2.4.0
     , fgl
     , file-embed
     , githash


### PR DESCRIPTION
The spec at https://eprint.iacr.org/2019/971.pdf has a copy of the BNF grammar in section 3.2 (page 19, figure 4).
```
  <authenticationQuery> ::= ‘authentication?’ <string> ‘→’ <string> ‘:’ <constant> (queryOptions)?
  <queryOptions> ::= ‘[’ <queryOption>* ‘]’
  <queryOption> ::= ‘precondition’ ‘[’ <message> ‘]’
```
Our parser currently does not handle queryOptions/queryOption, which leads to only authentication2.vp passing in the submitted tests.

Additional: Bump `Error.Diagnose` version, and revise `Main.hs` to work with the new version.

ping @sshine 